### PR TITLE
Bump bindgen version.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["api-bindings", "external-ffi-bindings", "network-programming", "o
 build = "build.rs"
 
 [build-dependencies]
-bindgen = "0.55.1"
+bindgen = "0.68.1"
 
 [dependencies]
 libc = "0.2.77"


### PR DESCRIPTION
Use newer bindgen version to unbreak the build on latest macOS.