### PR TITLE
Allow clippy::all

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
+#![allow(clippy::all)]
 
 include!(concat!(env!("OUT_DIR"), "/bindings2.rs"));
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));


### PR DESCRIPTION
## What

- allowed `clippy::all`

## Why

rust-analyzer has been picking up generated code for clippy which is annoying

## Manual Tests
Tested locally

## Documentation Updates
n/a
