### PR TITLE
fix: disable unnecessary managling

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -18,6 +18,7 @@ fn main() {
         .ctypes_prefix("::libc")
         .allowlist_file(".*dns_sd.h")
         .allowlist_recursively(false)
+        .trust_clang_mangling(false)
         .override_abi(Abi::System, "DNSService.*")
         .override_abi(Abi::System, "TXTRecord.*")
         .generate()


### PR DESCRIPTION
## What
Disable unnecessary managling.

## Why
Managling may conflict with `import_name_type = "undecorated"` on win x86. Since we use C functions only (no C++), we can safely disable it.

## Manual Tests
Yes. Works for win x86 & win x64. I believe it works on macOS too, but I have not a MacBook.

